### PR TITLE
詳細表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/_item-detail.html.erb
+++ b/app/views/items/_item-detail.html.erb
@@ -1,0 +1,41 @@
+<div class="item-explain-box">
+  <span><%= "商品説明" %></span>
+</div>
+<table class="detail-table">
+  <tbody>
+    <tr>
+      <th class="detail-item">出品者</th>
+      <td class="detail-value"><%= item.user.nick_name %></td>
+    </tr>
+    <tr>
+      <th class="detail-item">カテゴリー</th>
+      <td class="detail-value"><%= item.category.name %></td>
+    </tr>
+    <tr>
+      <th class="detail-item">商品の状態</th>
+      <td class="detail-value"><%= item.status.name %></td>
+    </tr>
+    <tr>
+      <th class="detail-item">配送料の負担</th>
+      <td class="detail-value"><%= item.delivery_charge.name %></td>
+    </tr>
+    <tr>
+      <th class="detail-item">発送元の地域</th>
+      <td class="detail-value"><%= item.shipment_source.name %></td>
+    </tr>
+    <tr>
+      <th class="detail-item">発送日の目安</th>
+      <td class="detail-value"><%= item.days_to_ship.name %></td>
+    </tr>
+  </tbody>
+</table>
+<div class="option">
+  <div class="favorite-btn">
+    <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+    <span>お気に入り 0</span>
+  </div>
+  <div class="report-btn">
+    <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+    <span>不適切な商品の通報</span>
+  </div>
+</div>

--- a/app/views/items/_item-list.html.erb
+++ b/app/views/items/_item-list.html.erb
@@ -1,5 +1,5 @@
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
       <% if @items.present? %>
-        <%= render partial: 'item-list', collection: @items, as: "item" %>| %>
+        <%= render partial: 'item-list', collection: @items, as: "item" %>
       <% else %>
         <%# 商品がない場合のダミー %>
         <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,68 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう 商品購入機能実装後に記述 %>
+      <%# <div class='sold-out'> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        (税込) 送料込み
+      </span>
+    </div>
+
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= render partial: "item-detail", locals: { item: @item } %>
+    <% elsif user_signed_in? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう 購入機能実装後に記述%>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%= render partial: "item-detail", locals: { item: @item } %>
+    <% else %>
+      <%= render partial: "item-detail", locals: { item: @item } %>
+    <% end %>
+
+ </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>


### PR DESCRIPTION
#What
showアクションを設定し、商品詳細機能を実装する

#Why
その後の商品編集機能、商品削除機能につなげていくため

商品詳細表示の分岐を３つに分けています。
①ログアウト状態では、商品詳細は見られるが、購入ボタンは非表示に
②ログインユーザーが他のユーザーの商品詳細を見た時は、購入ボタンが表示されるように
③ログインユーザーが自分の商品詳細を見た時は、購入ボタンは非表示に、「編集」「削除」ボタンが表示されるように
以上の点が実現できるように、部分テンプレートを活用して実装しました。他の機能（編集・削除・購入）に関わる記述は未完成です。コードレビューの方、よろしくお願いします。

・ログアウト状態で商品詳細表示
![ログアウト状態で商品詳細表示](https://user-images.githubusercontent.com/69967620/96723914-22ad7480-13ea-11eb-820f-e40fb28d2d95.gif)

・ログインユーザーが他のユーザーの商品を詳細表示
![ログインユーザーが他のユーザーの商品詳細表示](https://user-images.githubusercontent.com/69967620/96723899-1e815700-13ea-11eb-9255-74e756780635.gif)

・ログインユーザーが自分の商品を詳細表示
![ログインユーザーが自分の商品詳細表示](https://user-images.githubusercontent.com/69967620/96723783-fbef3e00-13e9-11eb-8324-552c9791da22.gif)


