### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all
@@ -31,6 +31,12 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :user_check, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all
@@ -52,5 +53,11 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def user_check
+    unless current_user.id == @item.user_id
+      render :show
+    end
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
       <%= render partial: "item-detail", locals: { item: @item } %>
     <% elsif user_signed_in? %>
       <%# 商品が売れていない場合はこちらを表示しましょう 購入機能実装後に記述%>


### PR DESCRIPTION
#What
商品削除機能の実装

#Why
出品者が商品削除機能によって商品を取り下げることができるようにするため

削除が成功した時のみトップページに戻るよう、itemsコントローラーのdestroyアクションにif文を入れていますが、必要ないかも知れません。コードレビューの方、よろしくお願い致します。

・商品削除の様子
![商品削除](https://user-images.githubusercontent.com/69967620/97104748-9d7fd380-16f9-11eb-8d52-c194f3ade922.gif)

